### PR TITLE
Add shutting down the executor

### DIFF
--- a/src/main/java/me/scarsz/jdaappender/ChannelLoggingHandler.java
+++ b/src/main/java/me/scarsz/jdaappender/ChannelLoggingHandler.java
@@ -44,7 +44,7 @@ public class ChannelLoggingHandler implements Flushable {
      * @return this channel logging handler
      */
     public ChannelLoggingHandler schedule(long period, @NotNull TimeUnit unit) {
-        shutdownExecutor(); // Stop the existing executor
+        shutdownExecutor(); // Stop the existing executor, if one exists
         if (executor == null) {
             executor = Executors.newSingleThreadScheduledExecutor();
         }


### PR DESCRIPTION
- Adds a method to shutdown the executor (`#shutdownExecutor`)
  + Calls it in `#schedule` to prevent having two running executors at the same time
- Adds a method to shutdown the executor & detach the logger (`#shutdown`)