### PR TITLE
Use MessageChannel instead of TextChannel for threads support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>me.scarsz</groupId>
     <artifactId>jdaappender</artifactId>
-    <version>1.0.2</version>
+    <version>1.1.0</version>
 
     <properties>
         <maven.compiler.source>8</maven.compiler.source>
@@ -64,7 +64,7 @@
         <dependency>
             <groupId>net.dv8tion</groupId>
             <artifactId>JDA</artifactId>
-            <version>4.3.0_305</version>
+            <version>5.0.0-alpha.11</version>
             <scope>provided</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
This allows the target channel for a logging stream to be a thread, see https://github.com/DiscordSRV/DiscordSRV/pull/1401 for more context. 

`recreateChannel` only works for "copyable" channels in the discord API, as well as channels that have a position in a guild listing. I decided to just leave this as a TextChannel for simplicity, although looking at the JDA docs more thoroughly it appears that `BaseGuildMessageChannel` might be more appropriate. I wasn't aware of this at the time I made the change. Regardless, it seems that `recreateChannel` is only used for testing, so it's probably not the end of the world either way.