### PR TITLE
Fix Unknown Message stacktrace loop in console

### DIFF
--- a/jda4/src/main/java/me/scarsz/jdaappender/ChannelLoggingHandler.java
+++ b/jda4/src/main/java/me/scarsz/jdaappender/ChannelLoggingHandler.java
@@ -239,15 +239,11 @@ public class ChannelLoggingHandler implements IChannelLoggingHandler, Flushable 
         if (currentMessage != null) {
             try {
                 return currentMessage.editMessage(full).submit().get();
-            } catch (ErrorResponseException e) {
-                if (e.getErrorResponse() == ErrorResponse.UNKNOWN_MESSAGE) {
-                    currentMessage = null;
-                } else {
-                    throw e;
-                }
             } catch (ExecutionException e) {
                 currentMessage = null;
-                throw new RuntimeException(e);
+                if (!(e.getCause() instanceof ErrorResponseException)) {
+                    throw new RuntimeException(e);
+                }
             } catch (InterruptedException e) {
                 JDA.Status status = channel.getJDA().getStatus();
                 if (status == JDA.Status.SHUTTING_DOWN || status == JDA.Status.SHUTDOWN) {

--- a/jda4/src/main/java/me/scarsz/jdaappender/ChannelLoggingHandler.java
+++ b/jda4/src/main/java/me/scarsz/jdaappender/ChannelLoggingHandler.java
@@ -246,6 +246,7 @@ public class ChannelLoggingHandler implements IChannelLoggingHandler, Flushable 
                     throw e;
                 }
             } catch (ExecutionException e) {
+                currentMessage = null;
                 throw new RuntimeException(e);
             } catch (InterruptedException e) {
                 JDA.Status status = channel.getJDA().getStatus();


### PR DESCRIPTION
The `#editMessage("...")` method throws a `ErrorResponseException`, but appending `.get()` wraps it in a `ExecutionException` exception. This means that `ErrorResponseException` needs to be checked from inside `ExecutionException`.

closes #18